### PR TITLE
Restore table of contents structure

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,5 +4,5 @@ theme: readthedocs
 repo_url: https://github.com/FakeItEasy/FakeItEasy.Analyzers
 extra_css: [css/extra-highlight.css]
 
-nav:
+pages:
 - FakeItEasy Analyzer: index.md


### PR DESCRIPTION
Contributes to FakeItEasy/FakeItEasy#1735, fixing a misconfiguration introduced in #5.