### PR TITLE
Downgrade Microsoft.CodeAnalysis.*.Workspaces to 2.10.0 to support VS2017 15.9

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ bugs at runtime.
 
 ## Installation
 
-The analyzer works in Visual Studio 2015 Update 1 or later. Install one of these
+The analyzer works in Visual Studio 2017 version 15.9 or later. Install one of these
 NuGet packages in each project that needs it:
 
 - For C# projects: [FakeItEasy.Analyzer.CSharp](https://www.nuget.org/packages/FakeItEasy.Analyzer.CSharp)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,7 @@
   <PropertyGroup Label="Common package properties">
     <Company>Patrik Hägne</Company>
     <Copyright>Copyright (c) FakeItEasy contributors. (fakeiteasyfx@gmail.com)</Copyright>
+    <Authors>Thomas Levesque, FakeItEasy contributors</Authors>
     <PackageProjectUrl>https://fakeiteasy.github.io/</PackageProjectUrl>
     <PackageIcon>images/FakeItEasy.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -13,10 +14,15 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>FakeItEasy.Analyzer</RootNamespace>
+    <SignAssembly>true</SignAssembly>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.6" PrivateAssets="all" />
     <PackageReference Include="MinVer" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
@@ -24,5 +30,7 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)/FakeItEasy.png" Pack="true" PackagePath="images/FakeItEasy.png" />
   </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)FakeItEasy.Analyzer.Shared/FakeItEasy.Analyzer.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <RootNamespace>FakeItEasy.Analyzer</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/src/FakeItEasy.Analyzer.CSharp/FakeItEasy.Analyzer.CSharp.csproj
+++ b/src/FakeItEasy.Analyzer.CSharp/FakeItEasy.Analyzer.CSharp.csproj
@@ -1,24 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>FakeItEasy.Analyzer</RootNamespace>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <FileAlignment>512</FileAlignment>
-    <SignAssembly>true</SignAssembly>
     <DefineConstants>$(DefineConstants);CSHARP;LACKS_NULLABLE_ATTRIBUTES</DefineConstants>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Label="Package properties">
     <Title>FakeItEasy.Analyzer.CSharp</Title>
-    <Authors>Thomas Levesque, FakeItEasy contributors</Authors>
     <Description>Provides diagnostic analyzers to warn about incorrect usage of FakeItEasy in C#. Works in Visual Studio 2015 Update 1 or later.</Description>
     <PackageTags>$(PackageTags);csharp;c#</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.6" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" PrivateAssets="all" />
   </ItemGroup>
 
@@ -26,7 +18,5 @@
     <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)$(AssemblyName).pdb" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
-
-  <Import Project="..\FakeItEasy.Analyzer.Shared\FakeItEasy.Analyzer.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/src/FakeItEasy.Analyzer.CSharp/FakeItEasy.Analyzer.CSharp.csproj
+++ b/src/FakeItEasy.Analyzer.CSharp/FakeItEasy.Analyzer.CSharp.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FakeItEasy.Analyzer.Shared/ArgumentConstraintTypeMismatchAnalyzer.cs
+++ b/src/FakeItEasy.Analyzer.Shared/ArgumentConstraintTypeMismatchAnalyzer.cs
@@ -81,7 +81,7 @@ namespace FakeItEasy.Analyzer
                 if (nonNullableParameterType is object &&
                     constraintType.IsValueType &&
                     !constraintType.IsNullable() &&
-                    SymbolEqualityComparer.Default.Equals(constraintType, nonNullableParameterType))
+                    constraintType.Equals(nonNullableParameterType))
                 {
                     if (propertyFullName != "FakeItEasy.A`1.That")
                     {

--- a/src/FakeItEasy.Analyzer.VisualBasic/FakeItEasy.Analyzer.VisualBasic.csproj
+++ b/src/FakeItEasy.Analyzer.VisualBasic/FakeItEasy.Analyzer.VisualBasic.csproj
@@ -1,24 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>FakeItEasy.Analyzer</RootNamespace>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <FileAlignment>512</FileAlignment>
-    <SignAssembly>true</SignAssembly>
     <DefineConstants>$(DefineConstants);VISUAL_BASIC;LACKS_NULLABLE_ATTRIBUTES</DefineConstants>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Label="Package properties">
     <Title>FakeItEasy.Analyzer.VisualBasic</Title>
-    <Authors>Thomas Levesque, FakeItEasy contributors</Authors>
     <Description>Provides diagnostic analyzers to warn about incorrect usage of FakeItEasy in VB.NET. Works in Visual Studio 2015 Update 1 or later.</Description>
     <PackageTags>$(PackageTags);visualbasic;vb;vb.net</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.6" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.3.1" PrivateAssets="all" />
   </ItemGroup>
 
@@ -26,7 +18,5 @@
     <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/vb" Visible="false" />
     <None Include="$(OutputPath)$(AssemblyName).pdb" Pack="true" PackagePath="analyzers/dotnet/vb" Visible="false" />
   </ItemGroup>
-
-  <Import Project="..\FakeItEasy.Analyzer.Shared\FakeItEasy.Analyzer.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/src/FakeItEasy.Analyzer.VisualBasic/FakeItEasy.Analyzer.VisualBasic.csproj
+++ b/src/FakeItEasy.Analyzer.VisualBasic/FakeItEasy.Analyzer.VisualBasic.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.10.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FakeItEasy.Analyzer.CSharp.Tests/FakeItEasy.Analyzer.CSharp.Tests.csproj
+++ b/tests/FakeItEasy.Analyzer.CSharp.Tests/FakeItEasy.Analyzer.CSharp.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.3.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.10.0" PrivateAssets="all" />
     <ProjectReference Include="..\..\src\FakeItEasy.Analyzer.CSharp\FakeItEasy.Analyzer.CSharp.csproj" />
   </ItemGroup>
 

--- a/tests/FakeItEasy.Analyzer.VisualBasic.Tests/FakeItEasy.Analyzer.VisualBasic.Tests.csproj
+++ b/tests/FakeItEasy.Analyzer.VisualBasic.Tests/FakeItEasy.Analyzer.VisualBasic.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.10.0" PrivateAssets="all" />
     <ProjectReference Include="..\..\src\FakeItEasy.Analyzer.VisualBasic\FakeItEasy.Analyzer.VisualBasic.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Follow up to a conversation with @thomaslevesque. The package built from this works in VS2017 15.9 and in VS2019.
@thomaslevesque found the version list: https://github.com/dotnet/roslyn/wiki/NuGet-packages#versioning 