### PR TITLE
Add developmentDependency=true in packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,6 +11,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>https://github.com/FakeItEasy/FakeItEasy.Analyzers/releases</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #22 

Turned out to be quite easy, and it was even [documented](https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#developmentdependency)