### PR TITLE
Update MinVer to 2.3.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.6" PrivateAssets="all" />
-    <PackageReference Include="MinVer" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="2.3.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 


### PR DESCRIPTION
According to https://github.com/adamralph/minver/pull/347, if we start building with MinVer < 2.3.0 under dontet sdk 3.1.300, we might have problems