### PR TITLE
Resolve #41: False positive for FakeItEasy0003 when using argument constraint in CallToSet with indexer property

### DIFF
--- a/src/FakeItEasy.Analyzer.Shared/ArgumentConstraintOutsideCallSpecAnalyzer.cs
+++ b/src/FakeItEasy.Analyzer.Shared/ArgumentConstraintOutsideCallSpecAnalyzer.cs
@@ -23,8 +23,10 @@ namespace FakeItEasy.Analyzer
             ImmutableHashSet.Create(
                 "FakeItEasy.A.CallTo",
                 "FakeItEasy.A.CallTo`1",
+                "FakeItEasy.A.CallToSet`1",
                 "FakeItEasy.Fake`1.CallsTo",
                 "FakeItEasy.Fake`1.CallsTo`1",
+                "FakeItEasy.Fake`1.CallsToSet`1",
                 "FakeItEasy.Configuration.IPropertySetterAnyValueConfiguration`1.To");
 
         private static readonly ImmutableHashSet<string> SupportedArgumentConstraintProperties =

--- a/src/FakeItEasy.Analyzer.Shared/ArgumentConstraintOutsideCallSpecAnalyzer.cs
+++ b/src/FakeItEasy.Analyzer.Shared/ArgumentConstraintOutsideCallSpecAnalyzer.cs
@@ -56,7 +56,7 @@ namespace FakeItEasy.Analyzer
 
         private static bool IsInArgumentToMethodThatSupportsArgumentConstraints(SyntaxNode node, SyntaxNodeAnalysisContext context)
         {
-            while (node is object)
+            while (node is not null)
             {
                 switch (node.Kind())
                 {
@@ -73,8 +73,7 @@ namespace FakeItEasy.Analyzer
                         break;
                 }
 
-                var invocation = node as InvocationExpressionSyntax;
-                if (invocation is object && SupportsArgumentConstraints(invocation, context))
+                if (node is InvocationExpressionSyntax invocation && SupportsArgumentConstraints(invocation, context))
                 {
                     return true;
                 }

--- a/tests/FakeItEasy.Analyzer.CSharp.Tests/ArgumentConstraintOutsideCallSpecAnalyzerTests.cs
+++ b/tests/FakeItEasy.Analyzer.CSharp.Tests/ArgumentConstraintOutsideCallSpecAnalyzerTests.cs
@@ -134,6 +134,29 @@ namespace TheNamespace
 
         [Theory]
         [MemberData(nameof(Constraints))]
+        public void Diagnostic_should_not_be_triggered_in_A_CallTo_Indexer(string constraint)
+        {
+            string code = $@"using FakeItEasy;
+namespace TheNamespace
+{{
+    class TheClass
+    {{
+        void Test()
+        {{
+            var foo = A.Fake<IFoo>();
+            A.CallTo(() => foo[{constraint}]).Returns(42);
+        }}
+    }}
+
+    interface IFoo {{ int this[int key] {{ get; set; }} }}
+}}
+";
+
+            this.VerifyCSharpDiagnostic(code);
+        }
+
+        [Theory]
+        [MemberData(nameof(Constraints))]
         public void Diagnostic_should_not_be_triggered_in_A_CallToSet_To_Expression(string constraint)
         {
             string code = $@"using FakeItEasy;
@@ -149,6 +172,29 @@ namespace TheNamespace
     }}
 
     interface IFoo {{ int Bar {{ get; set; }} }}
+}}
+";
+
+            this.VerifyCSharpDiagnostic(code);
+        }
+
+        [Theory]
+        [MemberData(nameof(Constraints))]
+        public void Diagnostic_should_not_be_triggered_in_A_CallToSet_Indexer(string constraint)
+        {
+            string code = $@"using FakeItEasy;
+namespace TheNamespace
+{{
+    class TheClass
+    {{
+        void Test()
+        {{
+            var foo = A.Fake<IFoo>();
+            A.CallToSet(() => foo[{constraint}]).DoesNothing();
+        }}
+    }}
+
+    interface IFoo {{ int this[int key] {{ get; set; }} }}
 }}
 ";
 
@@ -180,7 +226,7 @@ namespace TheNamespace
 
         [Theory]
         [MemberData(nameof(Constraints))]
-        public void Diagnostic_should_not_be_triggered_in_Fake_CallTo_Action(string constraint)
+        public void Diagnostic_should_not_be_triggered_in_Fake_CallsTo_Action(string constraint)
         {
             string code = $@"using FakeItEasy;
 namespace TheNamespace
@@ -195,6 +241,29 @@ namespace TheNamespace
     }}
 
     interface IFoo {{ void Bar(int x); }}
+}}
+";
+
+            this.VerifyCSharpDiagnostic(code);
+        }
+
+        [Theory]
+        [MemberData(nameof(Constraints))]
+        public void Diagnostic_should_not_be_triggered_in_Fake_CallsTo_Indexer(string constraint)
+        {
+            string code = $@"using FakeItEasy;
+namespace TheNamespace
+{{
+    class TheClass
+    {{
+        void Test()
+        {{
+            var fake = new Fake<IFoo>();
+            fake.CallsTo(foo => foo[{constraint}]).Returns(42);
+        }}
+    }}
+
+    interface IFoo {{ int this[int key] {{ get; set; }} }}
 }}
 ";
 
@@ -218,6 +287,29 @@ namespace TheNamespace
     }}
 
     interface IFoo {{ int Bar {{ get; set; }} }}
+}}
+";
+
+            this.VerifyCSharpDiagnostic(code);
+        }
+
+        [Theory]
+        [MemberData(nameof(Constraints))]
+        public void Diagnostic_should_not_be_triggered_in_Fake_CallsToSet_Indexer(string constraint)
+        {
+            string code = $@"using FakeItEasy;
+namespace TheNamespace
+{{
+    class TheClass
+    {{
+        void Test()
+        {{
+            var fake = new Fake<IFoo>();
+            fake.CallsToSet(foo => foo[{constraint}]).DoesNothing();
+        }}
+    }}
+
+    interface IFoo {{ int this[int key] {{ get; set; }} }}
 }}
 ";
 

--- a/tests/FakeItEasy.Analyzer.VisualBasic.Tests/ArgumentConstraintOutsideCallSpecAnalyzerTests.cs
+++ b/tests/FakeItEasy.Analyzer.VisualBasic.Tests/ArgumentConstraintOutsideCallSpecAnalyzerTests.cs
@@ -1,6 +1,5 @@
 namespace FakeItEasy.Analyzer.VisualBasic.Tests
 {
-    using System.Collections.Generic;
     using FakeItEasy.Analyzer.Tests.Helpers;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Diagnostics;
@@ -127,6 +126,50 @@ End Namespace
 
         [Theory]
         [MemberData(nameof(Constraints))]
+        public void Diagnostic_should_not_be_triggered_in_A_CallTo_Indexer(string constraint)
+        {
+            string code = $@"Imports FakeItEasy
+Namespace TheNamespace
+    Class TheClass
+        Sub Test()
+            Dim foo = A.Fake(Of IFoo)()
+            A.CallTo(Function() foo.Item({constraint})).Returns(42)
+        End Sub
+    End Class
+
+    Interface IFoo
+        Property Item(ByVal key as Integer) As Integer
+    End Interface
+End Namespace
+";
+
+            this.VerifyVisualBasicDiagnostic(code);
+        }
+
+        [Theory]
+        [MemberData(nameof(Constraints))]
+        public void Diagnostic_should_not_be_triggered_in_A_CallTo_Default_Indexer(string constraint)
+        {
+            string code = $@"Imports FakeItEasy
+Namespace TheNamespace
+    Class TheClass
+        Sub Test()
+            Dim foo = A.Fake(Of IFoo)()
+            A.CallTo(Function() foo({constraint})).Returns(42)
+        End Sub
+    End Class
+
+    Interface IFoo
+        Default Property Item(ByVal key as Integer) As Integer
+    End Interface
+End Namespace
+";
+
+            this.VerifyVisualBasicDiagnostic(code);
+        }
+
+        [Theory]
+        [MemberData(nameof(Constraints))]
         public void Diagnostic_should_not_be_triggered_in_A_CallToSet_To_Expression(string constraint)
         {
             string code = $@"Imports FakeItEasy
@@ -140,6 +183,50 @@ Namespace TheNamespace
 
     Interface IFoo
         Property Bar As Integer
+    End Interface
+End Namespace
+";
+
+            this.VerifyVisualBasicDiagnostic(code);
+        }
+
+        [Theory]
+        [MemberData(nameof(Constraints))]
+        public void Diagnostic_should_not_be_triggered_in_A_CallToSet_Indexer(string constraint)
+        {
+            string code = $@"Imports FakeItEasy
+Namespace TheNamespace
+    Class TheClass
+        Sub Test()
+            Dim foo = A.Fake(Of IFoo)()
+            A.CallToSet(Function() foo.Item({constraint})).DoesNothing()
+        End Sub
+    End Class
+
+    Interface IFoo
+        Property Item(ByVal key as Integer) As Integer
+    End Interface
+End Namespace
+";
+
+            this.VerifyVisualBasicDiagnostic(code);
+        }
+
+        [Theory]
+        [MemberData(nameof(Constraints))]
+        public void Diagnostic_should_not_be_triggered_in_A_CallToSet_Default_Indexer(string constraint)
+        {
+            string code = $@"Imports FakeItEasy
+Namespace TheNamespace
+    Class TheClass
+        Sub Test()
+            Dim foo = A.Fake(Of IFoo)()
+            A.CallToSet(Function() foo({constraint})).DoesNothing()
+        End Sub
+    End Class
+
+    Interface IFoo
+        Default Property Item(ByVal key as Integer) As Integer
     End Interface
 End Namespace
 ";
@@ -171,7 +258,7 @@ End Namespace
 
         [Theory]
         [MemberData(nameof(Constraints))]
-        public void Diagnostic_should_not_be_triggered_in_Fake_CallTo_Action(string constraint)
+        public void Diagnostic_should_not_be_triggered_in_Fake_CallsTo_Action(string constraint)
         {
             string code = $@"Imports FakeItEasy
 Namespace TheNamespace
@@ -184,6 +271,50 @@ Namespace TheNamespace
 
     Interface IFoo
         Sub Bar(ByVal x As Integer)
+    End Interface
+End Namespace
+";
+
+            this.VerifyVisualBasicDiagnostic(code);
+        }
+
+        [Theory]
+        [MemberData(nameof(Constraints))]
+        public void Diagnostic_should_not_be_triggered_in_Fake_CallsTo_Indexer(string constraint)
+        {
+            string code = $@"Imports FakeItEasy
+Namespace TheNamespace
+    Class TheClass
+        Sub Test()
+            Dim fake = new Fake(Of IFoo)()
+            fake.CallsTo(Function(foo) foo.Item({constraint})).Returns(42)
+        End Sub
+    End Class
+
+    Interface IFoo
+        Property Item(ByVal key as Integer) As Integer
+    End Interface
+End Namespace
+";
+
+            this.VerifyVisualBasicDiagnostic(code);
+        }
+
+        [Theory]
+        [MemberData(nameof(Constraints))]
+        public void Diagnostic_should_not_be_triggered_in_Fake_CallsTo_Default_Indexer(string constraint)
+        {
+            string code = $@"Imports FakeItEasy
+Namespace TheNamespace
+    Class TheClass
+        Sub Test()
+            Dim fake = new Fake(Of IFoo)()
+            fake.CallsTo(Function(foo) foo({constraint})).Returns(42)
+        End Sub
+    End Class
+
+    Interface IFoo
+        Default Property Item(ByVal key as Integer) As Integer
     End Interface
 End Namespace
 ";
@@ -206,6 +337,50 @@ Namespace TheNamespace
 
     Interface IFoo
         Property Bar As Integer
+    End Interface
+End Namespace
+";
+
+            this.VerifyVisualBasicDiagnostic(code);
+        }
+
+        [Theory]
+        [MemberData(nameof(Constraints))]
+        public void Diagnostic_should_not_be_triggered_in_Fake_CallsToSet_Indexer(string constraint)
+        {
+            string code = $@"Imports FakeItEasy
+Namespace TheNamespace
+    Class TheClass
+        Sub Test()
+            Dim fake = new Fake(Of IFoo)()
+            fake.CallsToSet(Function(foo) foo.Item({constraint})).DoesNothing()
+        End Sub
+    End Class
+
+    Interface IFoo
+        Property Item(ByVal key as Integer) As Integer
+    End Interface
+End Namespace
+";
+
+            this.VerifyVisualBasicDiagnostic(code);
+        }
+
+        [Theory]
+        [MemberData(nameof(Constraints))]
+        public void Diagnostic_should_not_be_triggered_in_Fake_CallsToSet_Default_Indexer(string constraint)
+        {
+            string code = $@"Imports FakeItEasy
+Namespace TheNamespace
+    Class TheClass
+        Sub Test()
+            Dim fake = new Fake(Of IFoo)()
+            fake.CallsToSet(Function(foo) foo({constraint})).DoesNothing()
+        End Sub
+    End Class
+
+    Interface IFoo
+        Default Property Item(ByVal key as Integer) As Integer
     End Interface
 End Namespace
 ";


### PR DESCRIPTION
Fixes #41.

Usage of `A.CallToSet(...)` and `Fake.CallsToSet(...)` with an argument constraint will no longer throw FakeItEasy0003 warnings. As far as I am aware, these are only going to be valid when the property specification is an indexer, so those are the test cases I added.

Examples:
```C#
// C#
A.CallToSet(() => foo[A<string>._]).DoesNothing();
fake.CallsToSet(foo => foo[A<string>._]).DoesNothing();
```
```VB
// VB
A.CallToSet(Function() foo(A(Of Integer).Ignored)).DoesNothing()
fake.CallsToSet(Function(foo) foo(A(Of Integer).Ignored)).DoesNothing()
```

Please note that I am much less familiar with VB syntax in general, and have never used FakeItEasy with VB, so go easy on me if I messed that part up at all. I have no excuse if I messed up the C# part :grin:.