### PR TITLE
Require pymdown-extensions 10.0.1 or higher

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,8 @@
 mike == 1.1.2
 mkdocs == 1.4.2
 mkdocs-material == 8.5.10
+
+# Security risk: any file can be included as a snippet with pymdown-extensions < 10
+# https://github.com/advisories/GHSA-jh85-wwv9-24hv
+# May become unnecessary when mkdocs-material version is bumped.
+pymdown-extensions >= 10.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,14 +47,17 @@ packaging==22.0
     # via mkdocs
 pygments==2.14.0
     # via mkdocs-material
-pymdown-extensions==9.9
-    # via mkdocs-material
+pymdown-extensions==10.0.1
+    # via
+    #   -r requirements.in
+    #   mkdocs-material
 python-dateutil==2.8.2
     # via ghp-import
 pyyaml==6.0
     # via
     #   mike
     #   mkdocs
+    #   pymdown-extensions
     #   pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs


### PR DESCRIPTION
Fixes a security risk: any file can be included as a snippet with pymdown-extensions < 10

  https://github.com/advisories/GHSA-jh85-wwv9-24hv
  
Closes #54.